### PR TITLE
Only reactivate component on main mouse button

### DIFF
--- a/src/ui/symbol.tsx
+++ b/src/ui/symbol.tsx
@@ -58,8 +58,8 @@ export default function Symbol(props) {
                 setDisplayContextMenu(true);
                 event.preventDefault();
             }}
-            onMouseDown={() => {
-                if (!sheet.active) {
+            onMouseDown={(event) => {
+                if (!sheet.active && event.button == 0) { // button == 0 -> main button
                     sheet.deleteComponent(component);
                     sheet.activeComponent = component;
                 }


### PR DESCRIPTION
This should fix #15. This fix may not work for some unusual mouse types, or if the browser does not pass the event.button parameter as described in https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button