### PR TITLE
Only reregister on rotate when not the active component

### DIFF
--- a/src/model/components/component.tsx
+++ b/src/model/components/component.tsx
@@ -93,9 +93,10 @@ export default abstract class Component {
      * Forces a refresh of the component in sheet.
      */
     rotate() {
-        this.sheet.deregisterNodes(this.nodes);
+        const active = this.sheet.active && this == this.sheet.activeComponent;
+        if (!active) this.sheet.deregisterNodes(this.nodes);
         this._setOrientation((this.orientation + 1) % 2);
-        this.sheet.registerNodes(this.nodes);
+        if (!active) this.sheet.registerNodes(this.nodes);
     }
 
     /**


### PR DESCRIPTION
Fixes a bug that is a consequence of #23 