### PR TITLE
Fix context menu problem

### DIFF
--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -33,7 +33,7 @@ export default function Popup(props) {
     });
 
     return (<>
-        <div class="absolute top-0 left-0 w-screen h-screen bg-opacity-70 bg-neutral-900 z-50 flex items-center justify-center">
+        <div ref={ref} class="absolute top-0 left-0 w-screen h-screen bg-opacity-70 bg-neutral-900 z-50 flex items-center justify-center">
             <article class="w-10/12 max-h-[90%] md:w-8/12 bg-primary p-4 rounded-md overflow-y-scroll">
                 <header class="mb-3">
                     <h1 class="inline-block p-2">{title}</h1>


### PR DESCRIPTION
The reference to the element got lost during the wire merger. This adds it back in, thus making sure the context menu appears again.